### PR TITLE
Set DEM.Net project to pure .Net 8

### DIFF
--- a/DEM.Net.Core/DEM.Net.Core.csproj
+++ b/DEM.Net.Core/DEM.Net.Core.csproj
@@ -24,7 +24,7 @@
     <AssemblyVersion>0.4.0.0</AssemblyVersion>
     <FileVersion>0.4.0.0</FileVersion>
     <UserSecretsId>a9a5d6e1-3bb8-4dfd-ac6a-861f60dada50</UserSecretsId>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/DEM.Net.Core/Services/Adornments/AdornmentsService.cs
+++ b/DEM.Net.Core/Services/Adornments/AdornmentsService.cs
@@ -8,6 +8,7 @@ using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Linq;
 using System.Numerics;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace DEM.Net.Core
@@ -19,6 +20,10 @@ namespace DEM.Net.Core
 
         public AdornmentsService(MeshService meshService, ILogger<AdornmentsService> logger)
         {
+
+            if ( RuntimeInformation.IsOSPlatform( OSPlatform.Windows ) )
+              throw new PlatformNotSupportedException( "AdornmentsService is only supported on Windows platform." );
+
             this._meshService = meshService;
             this._logger = logger;
         }

--- a/DEM.Net.Core/Services/Adornments/AdornmentsService.cs
+++ b/DEM.Net.Core/Services/Adornments/AdornmentsService.cs
@@ -11,6 +11,8 @@ using System.Numerics;
 using System.Runtime.InteropServices;
 using System.Text;
 
+#pragma warning disable CA1416
+
 namespace DEM.Net.Core
 {
     public class AdornmentsService
@@ -21,7 +23,7 @@ namespace DEM.Net.Core
         public AdornmentsService(MeshService meshService, ILogger<AdornmentsService> logger)
         {
 
-            if ( RuntimeInformation.IsOSPlatform( OSPlatform.Windows ) )
+            if ( !RuntimeInformation.IsOSPlatform( OSPlatform.Windows ) )
               throw new PlatformNotSupportedException( "AdornmentsService is only supported on Windows platform." );
 
             this._meshService = meshService;
@@ -256,3 +258,5 @@ namespace DEM.Net.Core
 
     }
 }
+
+#pragma warning restore CA1416

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,39 +4,39 @@
     <PackageVersion Include="DotSpatial.Projections.NetStandard" Version="1.0.0" />
     <PackageVersion Include="GeoAPI.CoordinateSystems" Version="1.7.5" />
     <PackageVersion Include="GeoAPI.Core" Version="1.7.5" />
+    <PackageVersion Include="geometry3Sharp" Version="1.0.324" />
     <PackageVersion Include="LazyCache" Version="2.4.0" />
     <PackageVersion Include="LazyCache.AspNetCore" Version="2.4.0" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Extensions.Options" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="NetTopologySuite" Version="2.5.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Extensions.Options" Version="9.0.0" />
+    <PackageVersion Include="NetTopologySuite" Version="2.6.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="protobuf-net" Version="3.2.45" />
-    <PackageVersion Include="geometry3Sharp" Version="1.0.324" />
+    <PackageVersion Include="protobuf-net" Version="3.2.46" />
     <PackageVersion Include="SDSCore" Version="1.2.0" />
     <PackageVersion Include="SharpGLTF.Toolkit" Version="1.0.3" />
     <PackageVersion Include="SixLabors.Fonts" Version="2.0.9" />
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.7" />
     <PackageVersion Include="SixLabors.ImageSharp.Drawing" Version="2.1.5" />
-    <PackageVersion Include="System.Drawing.Common" Version="9.0.0" />
-    <PackageVersion Include="System.Numerics.Vectors" Version="4.6.0" />
-    <PackageVersion Include="xunit" Version="2.9.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="System.Drawing.Common" Version="8.0.14" />
+    <PackageVersion Include="System.Numerics.Vectors" Version="4.6.1" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- correct nuget packages to only use .Net 8 latest, per target framework
- changed Core AdornmentsService to throw exception if used on non-Windows platforms